### PR TITLE
Handles repeated start and stretches clock before ACK

### DIFF
--- a/arduino/i2c_multi/i2c_multi.c
+++ b/arduino/i2c_multi/i2c_multi.c
@@ -216,7 +216,7 @@ static inline void byte_handler_pio()
     i2c_multi->bytes_count++;
     if (i2c_multi->status != I2C_WRITE)
     {
-        received = pio_sm_get_blocking(i2c_multi->pio, i2c_multi->sm_read);
+      received = transpond_byte(pio_sm_get_blocking(i2c_multi->pio, i2c_multi->sm_read) >> 24); // Do the bit-reverse here as PIO instructions are scarce
     }
     if (i2c_multi->status == I2C_IDLE)
     {


### PR DESCRIPTION
- [Handles repeated start](https://github.com/dgatf/I2C-slave-multi-address-RP2040/issues/2)
- [Stretches clock before ACK](https://github.com/dgatf/I2C-slave-multi-address-RP2040/issues/3)